### PR TITLE
Make SchedulerClusterCombo's address arg defaulted to None

### DIFF
--- a/scaler/utility/network_util.py
+++ b/scaler/utility/network_util.py
@@ -1,0 +1,8 @@
+import socket
+
+def get_available_tcp_port(hostname: str = "127.0.0.1") -> int:
+    with socket.socket(socket.AddressFamily.AF_INET, socket.SocketKind.SOCK_STREAM) as sock:
+        sock.bind((hostname, 0))
+        return sock.getsockname()[1]
+
+

--- a/tests/test_balance.py
+++ b/tests/test_balance.py
@@ -2,7 +2,8 @@ import os
 import time
 import unittest
 
-from tests.utility import get_available_tcp_port, logging_test_name
+from tests.utility import logging_test_name
+from scaler.utility.network_util import get_available_tcp_port
 
 from scaler import Client, Cluster, SchedulerClusterCombo
 from scaler.utility.logging.utility import setup_logger

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -35,9 +35,9 @@ class TestClient(unittest.TestCase):
     def setUp(self) -> None:
         setup_logger()
         logging_test_name(self)
-        self.address = f"tcp://127.0.0.1:{get_available_tcp_port()}"
         self._workers = 3
-        self.cluster = SchedulerClusterCombo(address=self.address, n_workers=self._workers, event_loop="builtin")
+        self.cluster = SchedulerClusterCombo(n_workers=self._workers, event_loop="builtin")
+        self.address = self.cluster.get_address()
 
     def tearDown(self) -> None:
         self.cluster.shutdown()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,7 +5,7 @@ import time
 import unittest
 from concurrent.futures import CancelledError
 
-from tests.utility import get_available_tcp_port, logging_test_name
+from tests.utility import logging_test_name
 
 from scaler import Client, SchedulerClusterCombo
 from scaler.utility.exceptions import MissingObjects, ProcessorDiedError

--- a/tests/test_death_timeout.py
+++ b/tests/test_death_timeout.py
@@ -2,7 +2,8 @@ import logging
 import time
 import unittest
 
-from tests.utility import get_available_tcp_port, logging_test_name
+from tests.utility import logging_test_name
+from scaler.utility.network_util import get_available_tcp_port
 
 from scaler import Client, Cluster, SchedulerClusterCombo
 from scaler.io.config import (

--- a/tests/test_future.py
+++ b/tests/test_future.py
@@ -4,7 +4,8 @@ import unittest
 from concurrent.futures import CancelledError, as_completed
 from threading import Event
 
-from tests.utility import get_available_tcp_port, logging_test_name
+from tests.utility import logging_test_name
+from scaler.utility.network_util import get_available_tcp_port
 
 from scaler import Client, SchedulerClusterCombo
 from scaler.utility.logging.utility import setup_logger

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,7 +2,8 @@ import graphlib
 import time
 import unittest
 
-from tests.utility import get_available_tcp_port, logging_test_name
+from tests.utility import logging_test_name
+from scaler.utility.network_util import get_available_tcp_port
 
 from scaler import Client, SchedulerClusterCombo
 from scaler.utility.graph.optimization import cull_graph

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -1,7 +1,8 @@
 import time
 import unittest
 
-from tests.utility import get_available_tcp_port, logging_test_name
+from tests.utility import logging_test_name
+from scaler.utility.network_util import get_available_tcp_port
 
 from scaler import Client, SchedulerClusterCombo
 from scaler.utility.logging.utility import setup_logger

--- a/tests/test_protected.py
+++ b/tests/test_protected.py
@@ -1,7 +1,8 @@
 import time
 import unittest
 
-from tests.utility import get_available_tcp_port, logging_test_name
+from tests.utility import logging_test_name
+from scaler.utility.network_util import get_available_tcp_port
 
 from scaler import Client, SchedulerClusterCombo
 from scaler.utility.logging.utility import setup_logger

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -5,7 +5,8 @@ import unittest
 from typing import Any
 
 import cloudpickle
-from tests.utility import get_available_tcp_port, logging_test_name
+from tests.utility import logging_test_name
+from scaler.utility.network_util import get_available_tcp_port
 
 from scaler import Client, SchedulerClusterCombo, Serializer
 from scaler.utility.logging.scoped_logger import ScopedLogger

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -2,8 +2,8 @@ import random
 import time
 import unittest
 
-from tests.utility import get_available_tcp_port, logging_test_name
-
+from tests.utility import logging_test_name
+from scaler.utility.network_util import get_available_tcp_port
 from scaler import Client, SchedulerClusterCombo
 from scaler.utility.logging.scoped_logger import ScopedLogger
 from scaler.utility.logging.utility import setup_logger

--- a/tests/utility.py
+++ b/tests/utility.py
@@ -2,12 +2,5 @@ import logging
 import socket
 import unittest
 
-
-def get_available_tcp_port(hostname: str = "127.0.0.1") -> int:
-    with socket.socket(socket.AddressFamily.AF_INET, socket.SocketKind.SOCK_STREAM) as sock:
-        sock.bind((hostname, 0))
-        return sock.getsockname()[1]
-
-
 def logging_test_name(obj: unittest.TestCase):
     logging.info(f"{obj.__class__.__name__}:{obj._testMethodName} ==============================================")

--- a/tests/utility.py
+++ b/tests/utility.py
@@ -1,5 +1,4 @@
 import logging
-import socket
 import unittest
 
 def logging_test_name(obj: unittest.TestCase):


### PR DESCRIPTION
Internally, `SchedulerClusterCombo` will get an available port and use that. User will then get address through `get_address` method.