### PR TITLE
Prevents the Pillow example to override the repository's content.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ venv*/
 
 dask-worker-space/*
 .pre-commit-config.yaml
+
+.DS_Store


### PR DESCRIPTION
The Pillow example will not update the example images that are in the repository, but use temporary files instead.