### PR TITLE
Use so as server

### DIFF
--- a/scaler/object_storage/CMakeLists.txt
+++ b/scaler/object_storage/CMakeLists.txt
@@ -1,29 +1,9 @@
-include(FetchContent)
-set(ARGPARSE_GIT_REPOSITORY "https://github.com/p-ranav/argparse.git")
-set(ARGPARSE_GIT_TAG "d924b84eba1f0f0adf38b20b7b4829f6f65b6570")
-FetchContent_Declare(
-    argparse
-    GIT_REPOSITORY ${ARGPARSE_GIT_REPOSITORY}
-    GIT_TAG ${ARGPARSE_GIT_TAG}
-)
-FetchContent_MakeAvailable(argparse)
-message(STATUS "Fetched argparse from ${ARGPARSE_GIT_REPOSITORY} @ ${ARGPARSE_GIT_TAG}")
-
-add_executable(server)
-# add_library(server_as_so SHARED)
+add_library(server SHARED)
 
 target_sources(server PRIVATE
   server.cpp
   io_helper.cpp
 )
-
-# target_sources(server_as_so PRIVATE
-#   server_as_so.cpp
-#   io_helper.cpp
-# )
-
-target_link_libraries(server PRIVATE argparse)
-# target_link_libraries(server_as_so PRIVATE argparse)
 
 set(CAPNPC_SRC_PREFIX "${PROJECT_SOURCE_DIR}/scaler/protocol/capnp" CACHE STRING "" FORCE)
 set(CAPNPC_OUTPUT_DIR "${CMAKE_BINARY_DIR}/protocol" CACHE STRING "" FORCE)

--- a/scaler/object_storage/server.h
+++ b/scaler/object_storage/server.h
@@ -1,0 +1,5 @@
+#pragma once
+
+extern "C" {
+void run_object_storage_server(const char* name_, const char* port);
+}

--- a/scaler/object_storage/server.py
+++ b/scaler/object_storage/server.py
@@ -1,0 +1,42 @@
+import argparse
+import ctypes
+import sys
+
+def load_library(lib_path):
+    """
+    Load the shared dynamic library.
+    """
+    try:
+        return ctypes.CDLL(lib_path)
+    except OSError as e:
+        print(f"Failed to load library: {e}")
+        sys.exit(1)
+
+def run_object_storage_server(lib_path: str, name: str = "127.0.0.1", port: str = "55555"):
+    # Load the library
+    lib = load_library(lib_path=lib_path)
+    # Define the argument and return types for the main_entrance function
+    lib.run_object_storage_server.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    lib.run_object_storage_server.restype = None
+
+    # Call the function
+    name_bytes = name.encode('utf-8')
+    port_bytes = port.encode('utf-8')
+
+    lib.run_object_storage_server(name_bytes, port_bytes)
+
+def main():
+    parser = argparse.ArgumentParser(description='Call main_entrance from a dynamic library.')
+    parser.add_argument('--lib', required=True, help='Path to the foundational library')
+    parser.add_argument('--name', '-n', default='127.0.0.1', 
+                        help='Ip address or NS record. Default to 127.0.0.1')
+    parser.add_argument('--port', '-p', default='55555', 
+                        help='Port number to connect. Default to 55555')
+    args = parser.parse_args()
+
+    run_object_storage_server(args.lib, args.name, args.port)
+
+
+if __name__ == '__main__':
+    main()
+

--- a/scaler/object_storage/tests/CMakeLists.txt
+++ b/scaler/object_storage/tests/CMakeLists.txt
@@ -7,6 +7,17 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
+include(FetchContent)
+set(ARGPARSE_GIT_REPOSITORY "https://github.com/p-ranav/argparse.git")
+set(ARGPARSE_GIT_TAG "d924b84eba1f0f0adf38b20b7b4829f6f65b6570")
+FetchContent_Declare(
+    argparse
+    GIT_REPOSITORY ${ARGPARSE_GIT_REPOSITORY}
+    GIT_TAG ${ARGPARSE_GIT_TAG}
+)
+FetchContent_MakeAvailable(argparse)
+message(STATUS "Fetched argparse from ${ARGPARSE_GIT_REPOSITORY} @ ${ARGPARSE_GIT_TAG}")
+
 add_executable(
   test_scaler_object
   test_scaler_object.cpp
@@ -25,6 +36,13 @@ target_include_directories(test_scaler_object PRIVATE ${CMAKE_BINARY_DIR})
 include(GoogleTest)
 gtest_discover_tests(test_scaler_object)
 
-# add_executable(test_scaler_so test_scaler_so.cpp)
-# target_include_directories(test_scaler_so PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
-# target_link_libraries(test_scaler_so PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../libserver_as_so.so)
+add_executable(test_server_main 
+  test_server_main.cpp
+  ../io_helper.cpp
+)
+
+target_include_directories(test_server_main PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_sources(test_server_main PRIVATE ${objectStorageSources})
+target_link_libraries(test_server_main PRIVATE CapnProto::capnp)
+target_include_directories(test_server_main PRIVATE ${CMAKE_BINARY_DIR})
+target_link_libraries(test_server_main PRIVATE argparse)


### PR DESCRIPTION
A python wrapper to object storage server

- `server.py` can be executed as a program. In this case, it depends on
  python-argparse. It can also be executed as a separate module. In this
  case, user call `run_object_storage_server` and the server will be
  started. Note, if the use case is always to call
  `run_object_storage_server`, then the program should remove argparse
  as its dependencies. The caller, is expected to fill in legit args.

- The original server_as_so is renamed as server. `server` is now a
  dynamic library, that can be accepted by server.py. The original
  `server` executable is now moved to tests/test_server_main. This
  program is meant to be used in testing.

- Dependency changes: For non-testing purposes, C++ argparse is not
  a dependency. pyargparse is not a dependency to server.py if it is
  directly executed. Otherwise, pyargparse is not a dependency.

Signed-off-by: gxu <georgexu420@gmail.com>
