### PR TITLE
Make github action cache dependencies

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -38,32 +38,41 @@ jobs:
           sudo apt install software-properties-common -y
           sudo apt install cmake clang curl pkg-config -y
 
+      - name: Make scripts executable
+        run: |
+          sudo chmod 755 ./scripts/download_install_dependencies.sh
+
       - name: Cache Boost
         id: cache-boost
         uses: actions/cache@v4
         with:
-          path: /usr/include/boost
-          key: ${{ runner.os }}-boost
+          path: boost
+          key: ${{ runner.os }}-cache-boost
 
-      - name: Install Boost
+      - name: Download Boost if not cached
         if: steps.cache-boost.outputs.cache-hit != 'true'
         run: |
-          sudo chmod 755 ./scripts/download_install_dependencies.sh
-          sudo ./scripts/download_install_dependencies.sh boost
+          sudo ./scripts/download_install_dependencies.sh boost compile
+
+      - name: Install Boost
+        run: |
+          sudo ./scripts/download_install_dependencies.sh boost install
 
       - name: Cache Capnp
         id: cache-capnp
         uses: actions/cache@v4
         with:
-          path: /usr/include/capnp
-          key: ${{ runner.os }}-capnp
+          path: capnp
+          key: ${{ runner.os }}-cache-capnp
 
-      - name: Install Capnp
+      - name: Download and Compile capnp is not cached
         if: steps.cache-capnp.outputs.cache-hit != 'true'
         run: |
-          sudo chmod 755 ./scripts/download_install_dependencies.sh
-          sudo ./scripts/download_install_dependencies.sh capnp
+          sudo ./scripts/download_install_dependencies.sh capnp compile
 
+      - name: Install Capnp
+        run: |
+          sudo ./scripts/download_install_dependencies.sh capnp install
 
       - name: Build Object Storage Component
         run: |

--- a/scripts/download_install_dependencies.sh
+++ b/scripts/download_install_dependencies.sh
@@ -7,29 +7,41 @@ BOOST_VERSION="1.88.0"
 CAPNP_VERSION="1.1.0"
 
 if [ "$1" == "boost" ]; then
-	BOOST_FOLDER_NAME="boost_$(echo $BOOST_VERSION | tr '.' '_')"
-	BOOST_PACKAGE_NAME=${BOOST_FOLDER_NAME}.tar.gz
-	curl -O https://archives.boost.io/release/${BOOST_VERSION}/source/${BOOST_PACKAGE_NAME} --retry 100 --retry-max-time 3600
-	tar -xzf ${BOOST_PACKAGE_NAME}
-	sudo mkdir -p /usr/include/boost
-	sudo mv ${BOOST_FOLDER_NAME}/boost /usr/include/.
-	echo "Installed Boost into /usr/include/boost"
-	sudo rm -rf ${BOOST_FOLDER_NAME} ${BOOST_PACKAGE_NAME}
+	if [ "$2" == "compile" ]; then
+		BOOST_FOLDER_NAME="boost_$(echo $BOOST_VERSION | tr '.' '_')"
+		BOOST_PACKAGE_NAME=${BOOST_FOLDER_NAME}.tar.gz
+		curl -O https://archives.boost.io/release/${BOOST_VERSION}/source/${BOOST_PACKAGE_NAME} --retry 100 --retry-max-time 3600
+		tar -xzf ${BOOST_PACKAGE_NAME}
+		mv ${BOOST_FOLDER_NAME} boost
+	elif [ "$2" == "install" ]; then
+		sudo cp -r boost/boost /usr/include/.
+		echo "Installed Boost into /usr/include/boost"
+	else 
+		echo "Argument needs to be either compile or install"
+		exit 1
+	fi
 
 elif [ "$1" == "capnp" ]; then
-	CAPNP_FOLDER_NAME="capnproto-c++-$(echo $CAPNP_VERSION)"
-	CAPNP_PACKAGE_NAME=${CAPNP_FOLDER_NAME}.tar.gz
-	curl -O https://capnproto.org/${CAPNP_PACKAGE_NAME} --retry 100 --retry-max-time 3600
-	tar -xzf ${CAPNP_PACKAGE_NAME}
-	cd ${CAPNP_FOLDER_NAME}
-	./configure --prefix=/usr/
-	make -j6 check
-	sudo make install
-	echo "Installed capnp into /usr"
-	sudo rm -rf ${CAPNP_FOLDER_NAME} ${CAPNP_PACKAGE_NAME}
+	if [ "$2" == "compile" ]; then
+		CAPNP_FOLDER_NAME="capnproto-c++-$(echo $CAPNP_VERSION)"
+		CAPNP_PACKAGE_NAME=${CAPNP_FOLDER_NAME}.tar.gz
+		curl -O https://capnproto.org/${CAPNP_PACKAGE_NAME} --retry 100 --retry-max-time 3600
+		tar -xzf ${CAPNP_PACKAGE_NAME}
+		mv ${CAPNP_FOLDER_NAME} capnp
+		cd capnp
+		./configure --prefix=/usr/
+		make -j6 check
+	elif [ "$2" == "install" ]; then
+		cd capnp
+		sudo make install
+		echo "Installed capnp into /usr"
+	else 
+		echo "Argument needs to be either compile or install"
+		exit 1
+	fi
 
 else 
-    echo "Usage: ./download_install_dependencies.sh [boost|capnp]"
+    echo "Usage: ./download_install_dependencies.sh [boost|capnp] [compile|install]"
     exit 1
 fi
 


### PR DESCRIPTION
Another try to make github action cache dependencies This time, we do not cache system library. Instead, we cache local directory and only cache the compile steps. Installing is not taking a lot of time anyway.