### PR TITLE
Change protocol

### DIFF
--- a/examples/applications/requirements_applications.txt
+++ b/examples/applications/requirements_applications.txt
@@ -1,4 +1,4 @@
-yfinance
+yfinance==0.2.56
 scipy
 numpy
 nest-asyncio

--- a/scaler/object_storage/constants.h
+++ b/scaler/object_storage/constants.h
@@ -8,7 +8,7 @@
 namespace scaler {
 namespace object_storage {
 
-static constexpr size_t CAPNP_HEADER_SIZE     = 72;
+static constexpr size_t CAPNP_HEADER_SIZE     = 80;
 static constexpr size_t CAPNP_WORD_SIZE       = sizeof(capnp::word);
 static constexpr size_t MEMORY_LIMIT_IN_BYTES = 6uz << 40;  // 6 TB
 static constexpr const char* DEFAULT_ADDR     = "127.0.0.1";

--- a/scaler/object_storage/defs.h
+++ b/scaler/object_storage/defs.h
@@ -18,15 +18,17 @@ using payload_t       = std::vector<unsigned char>;
 struct ObjectRequestHeader {
     object_id_t objectID;
     uint64_t payloadLength;
+    uint64_t requestID;
     ::ObjectRequestHeader::ObjectRequestType reqType;
-    ObjectRequestHeader(): objectID {}, payloadLength {}, reqType {} {}
+    ObjectRequestHeader(): objectID {}, payloadLength {}, requestID {}, reqType {} {}
 };
 
 struct ObjectResponseHeader {
     object_id_t objectID;
     uint64_t payloadLength;
+    uint64_t responseID;
     ::ObjectResponseHeader::ObjectResponseType respType;
-    ObjectResponseHeader(): objectID {}, payloadLength {}, respType {} {}
+    ObjectResponseHeader(): objectID {}, payloadLength {}, responseID {}, respType {} {}
 };
 
 };  // namespace object_storage

--- a/scaler/object_storage/io_helper.cpp
+++ b/scaler/object_storage/io_helper.cpp
@@ -15,6 +15,7 @@
 #include <boost/asio/use_awaitable.hpp>
 #include <boost/asio/write.hpp>
 #include <boost/system/system_error.hpp>
+#include <exception>
 #include <iostream>
 
 #include "protocol/object_storage.capnp.h"
@@ -87,7 +88,8 @@ awaitable<void> read_request_payload(tcp::socket& socket, ObjectRequestHeader& h
         std::size_t n = co_await boost::asio::async_read(socket, boost::asio::buffer(payload), use_awaitable);
     } catch (boost::system::system_error& e) {
         std::cerr << "payload ends prematurely, e.what() = " << e.what() << '\n';
-        throw e;
+        std::cerr << "Failing fast. Terminting now...\n";
+        std::terminate();
     }
 }
 
@@ -98,6 +100,10 @@ boost::asio::awaitable<void> write_response_payload(
     } catch (boost::system::system_error& e) {
         if (e.code() == boost::asio::error::broken_pipe) {
             std::cerr << "Remote end closed, nothing to write.\n";
+            std::cerr << "This should never happen as the client is expected "
+                      << "to get every and all response. Terminating now...\n";
+
+            std::terminate();
         } else {
             std::cerr << "write error e.what() = " << e.what() << '\n';
         }
@@ -125,6 +131,9 @@ boost::asio::awaitable<void> write_response_header(
         // TODO: Log support
         if (e.code() == boost::asio::error::broken_pipe) {
             std::cerr << "Remote end closed, nothing to write.\n";
+            std::cerr << "This should never happen as the client is expected "
+                      << "to get every and all response. Terminating now...\n";
+            std::terminate();
         } else {
             std::cerr << "write error e.what() = " << e.what() << '\n';
         }

--- a/scaler/object_storage/object_storage_server.h
+++ b/scaler/object_storage/object_storage_server.h
@@ -22,15 +22,15 @@ using boost::asio::use_awaitable;
 using boost::asio::ip::tcp;
 
 class ObjectStorageServer {
-    struct meta {
+    struct Meta {
         std::shared_ptr<boost::asio::ip::tcp::socket> socket;
         ObjectRequestHeader requestHeader;
         ObjectResponseHeader responseHeader;
     };
 
-    struct object_with_meta {
+    struct ObjectWithMeta {
         shared_object_t object;
-        std::vector<meta> metaInfo;
+        std::vector<Meta> metaInfo;
     };
 
     using reqType  = ::ObjectRequestHeader::ObjectRequestType;
@@ -85,7 +85,7 @@ public:
     }
 
 private:
-    awaitable<void> write_once(meta meta) {
+    awaitable<void> write_once(Meta meta) {
         if (meta.requestHeader.reqType == reqType::GET_OBJECT) {
             meta.responseHeader.payloadLength =
                 std::min(objectIDToMeta[meta.responseHeader.objectID].object->size(), meta.requestHeader.payloadLength);
@@ -103,7 +103,7 @@ private:
                     co_await write_once(std::move(curr_meta));
                 } catch (boost::system::system_error& e) {}
             }
-            objectIDToMeta[requestHeader.objectID].metaInfo = std::vector<meta>();
+            objectIDToMeta[requestHeader.objectID].metaInfo = std::vector<Meta>();
         }
         co_return;
     }
@@ -111,7 +111,7 @@ private:
 #ifndef NDEBUG
 public:
 #endif
-    std::map<scaler::object_storage::object_id_t, object_with_meta> objectIDToMeta;
+    std::map<scaler::object_storage::object_id_t, ObjectWithMeta> objectIDToMeta;
 
 public:
     awaitable<void> process_request(std::shared_ptr<tcp::socket> socket) {

--- a/scaler/object_storage/object_storage_server.h
+++ b/scaler/object_storage/object_storage_server.h
@@ -6,6 +6,7 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/system/system_error.hpp>
+#include <iostream>
 #include <map>
 
 #include "defs.h"
@@ -101,7 +102,9 @@ private:
             for (auto& curr_meta: objectIDToMeta[requestHeader.objectID].metaInfo) {
                 try {
                     co_await write_once(std::move(curr_meta));
-                } catch (boost::system::system_error& e) {}
+                } catch (boost::system::system_error& e) {
+                    std::cerr << "Mostly because some connections disconnected accidentally.\n";
+                }
             }
             objectIDToMeta[requestHeader.objectID].metaInfo = std::vector<Meta>();
         }

--- a/scaler/object_storage/server.cpp
+++ b/scaler/object_storage/server.cpp
@@ -60,5 +60,8 @@ void run_object_storage_server(const char* name_, const char* port_) {
         co_spawn(io_context, listener(res.begin()->endpoint()), detached);
 
         io_context.run();
-    } catch (std::exception& e) { std::printf("Exception: %s\n", e.what()); }
+    } catch (std::exception& e) {
+        std::printf("Exception: %s\n", e.what());
+        std::printf("Mostly something serious happen, inspect capnp header correuption\n");
+    }
 }

--- a/scaler/object_storage/server.cpp
+++ b/scaler/object_storage/server.cpp
@@ -11,13 +11,9 @@
 #include <boost/asio/this_coro.hpp>
 #include <boost/system/system_error.hpp>
 #include <cstdio>
-#include <cstdlib>
-#include <cstring>
 #include <string>
 
-#include "constants.h"
 #include "object_storage_server.h"
-#include "version.h"
 
 // Helper macros to stringify the macro value
 #define STRINGIFY_HELPER(x) #x
@@ -46,6 +42,7 @@ awaitable<void> listener(boost::asio::ip::tcp::endpoint endpoint) {
 }
 
 // Assuming name_ and port_ is valid name and port
+// TODO: In the future we might need to add expiration date for closing connections
 void run_object_storage_server(const char* name_, const char* port_) {
     std::string name = name_;
     std::string port = port_;

--- a/scaler/protocol/capnp/object_storage.capnp
+++ b/scaler/protocol/capnp/object_storage.capnp
@@ -3,7 +3,8 @@
 struct ObjectRequestHeader {
     objectID @0: ObjectID; # 32 bytes
     payloadLength @1: UInt64; # 8 bytes
-    requestType @2: ObjectRequestType; # 2 bytes
+    requestID @2: UInt64; # 8 bytes
+    requestType @3: ObjectRequestType; # 2 bytes
 
     enum ObjectRequestType {
         setObject @0;       # send object to object storage, in the future, we might provide expiration time
@@ -22,7 +23,8 @@ struct ObjectID {
 struct ObjectResponseHeader {
     objectID @0: ObjectID;
     payloadLength @1: UInt64;
-    responseType @2: ObjectResponseType;
+    responseID @2: UInt64; # 8 bytes
+    responseType @3: ObjectResponseType;
 
     enum ObjectResponseType {
         setOK @0;

--- a/tests/object_storage/test_scaler_object.cpp
+++ b/tests/object_storage/test_scaler_object.cpp
@@ -15,6 +15,7 @@
 #include "protocol/object_storage.capnp.h"
 #include "scaler/object_storage/constants.h"
 #include "scaler/object_storage/defs.h"
+#include "scaler/object_storage/io_helper.h"
 #include "scaler/object_storage/server.h"
 
 using boost::asio::buffer;
@@ -359,6 +360,45 @@ TEST_F(ServerClientTest, TestEmptyObject) {
     requestHeader.reqType = req_type::DELETE_OBJECT;
     write_request_header(socket, requestHeader, 10);
     read_response_header(socket, responseHeader);
+
+    boost::system::error_code ec;
+    auto res = socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
+    (void)res;
+}
+
+TEST_F(ServerClientTest, TestRequestBlocking) {
+    boost::asio::io_context io_context;
+    tcp::socket socket(io_context);
+    tcp::resolver resolver(io_context);
+    boost::asio::connect(socket, resolver.resolve("127.0.0.1", "55555"));
+
+    scaler::object_storage::ObjectRequestHeader requestHeader;
+    requestHeader.objectID  = {0xdead, 0xbeef, 0xdead, 0xbeef};
+    requestHeader.requestID = 42;
+    requestHeader.reqType   = req_type::GET_OBJECT;
+    write_request_header(socket, requestHeader, sizeof(payload));
+
+    requestHeader.requestID = 43;
+    requestHeader.reqType   = req_type::SET_OBJECT;
+    write_request_header(socket, requestHeader, sizeof(payload));
+    write_payload(socket);
+
+    scaler::object_storage::ObjectResponseHeader responseHeader;
+    read_response_header(socket, responseHeader);
+
+    char buf[sizeof(payload)] {};
+    if (responseHeader.responseID == 42) {
+        boost::asio::read(socket, buffer(buf));
+        EXPECT_EQ(responseHeader.objectID, requestHeader.objectID);
+        EXPECT_EQ(std::string(buf), std::string(payload));
+        read_response_header(socket, responseHeader);
+        EXPECT_EQ(responseHeader.responseID, 43);
+    } else if (responseHeader.responseID == 43) {
+        read_response_header(socket, responseHeader);
+        EXPECT_EQ(responseHeader.responseID, 42);
+        boost::asio::read(socket, buffer(buf));
+        EXPECT_EQ(std::string(buf), std::string(payload));
+    }
 
     boost::system::error_code ec;
     auto res = socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);

--- a/tests/object_storage/test_scaler_object.cpp
+++ b/tests/object_storage/test_scaler_object.cpp
@@ -153,6 +153,7 @@ void write_request_header(
     auto req_root = req_msg.initRoot<::ObjectRequestHeader>();
     req_root.setRequestType(header.reqType);
     req_root.setPayloadLength(payload_length);
+    req_root.setRequestID(header.requestID);
     auto req_root_object_id = req_root.initObjectID();
     req_root_object_id.setField0(header.objectID[0]);
     req_root_object_id.setField1(header.objectID[1]);
@@ -174,6 +175,7 @@ void read_response_header(tcp::socket& socket, scaler::object_storage::ObjectRes
 
         header.respType      = request_root.getResponseType();
         header.payloadLength = request_root.getPayloadLength();
+        header.responseID    = request_root.getResponseID();
 
         auto object_id  = request_root.getObjectID();
         header.objectID = {
@@ -387,6 +389,7 @@ TEST_F(ServerClientTest, TestRequestBlocking) {
     read_response_header(socket, responseHeader);
 
     char buf[sizeof(payload)] {};
+
     if (responseHeader.responseID == 42) {
         boost::asio::read(socket, buffer(buf));
         EXPECT_EQ(responseHeader.objectID, requestHeader.objectID);


### PR DESCRIPTION
Please review this protocol change. Please be noted that the `requestID` should be way, way, way beyond how much object you would actually want to send - they are independent in each connection. A tempting idea is to reserve the top/bottom 32 bits. But that is up for discussion.

Beside this, current implementation lacks the ability to "know how much to read". That being said, if we would like to not using `read/write` process request model then we will have to "try read x bytes" before we process. Should we also add a mechanism for user to tell the server how much messages are there?