### PR TITLE
Fix package directory cannot be found error

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -61,4 +61,4 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@db8f07d3871a0a180efa06b95d467625c19d5d5f # release/v1
         with:
-          path: ./wheelhouse/
+          packages_dir: ./wheelhouse/


### PR DESCRIPTION
The error message seems to be stating "path" is not a recognized variable, and prompted packages_dir to be the correct one. Let's try that.