### PR TITLE
Object storage server protocol v6

### DIFF
--- a/scaler/protocol/capnp/object_storage.capnp
+++ b/scaler/protocol/capnp/object_storage.capnp
@@ -28,9 +28,8 @@ struct ObjectResponseHeader {
 
     enum ObjectResponseType {
         setOK @0;
-        setOKOverride @1;
-        getOK @2;             # if object not exists, it will hang
-        delOK @3;
-        delNotExists @4;
+        getOK @1;             # if object not exists, it will hang
+        delOK @2;
+        delNotExists @3;
     }
 }

--- a/tests/object_storage/test_scaler_object.cpp
+++ b/tests/object_storage/test_scaler_object.cpp
@@ -225,7 +225,6 @@ TEST_F(ServerClientTest, TestSetObject) {
     read_response_header(socket, responseHeader);
     EXPECT_EQ(responseHeader.objectID, requestHeader.objectID);
     EXPECT_EQ(responseHeader.payloadLength, 0);
-    EXPECT_EQ(responseHeader.respType, resp_type::SET_O_K_OVERRIDE);
 
     boost::system::error_code ec;
     auto res = socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);


### PR DESCRIPTION
- Internally manage hashes of each object to optimize memory footprint.
- Remove the set_ok_override return option. 