### PR TITLE
webui: cap displayed cpu usage to 100

### DIFF
--- a/scaler/ui/live_display.py
+++ b/scaler/ui/live_display.py
@@ -57,9 +57,9 @@ class WorkerRow:
 
     def populate(self, data: WorkerStatus):
         self.worker = data.worker_id.decode()
-        self.agt_cpu = data.agent.cpu / 10
+        self.agt_cpu = min(data.agent.cpu / 10, 100.0)
         self.agt_rss = int(data.agent.rss / 1e6)
-        self.cpu = sum(p.resource.cpu for p in data.processor_statuses) / 10
+        self.cpu = min(sum(p.resource.cpu for p in data.processor_statuses) / 10, 100.0)
         self.rss = int(sum(p.resource.rss for p in data.processor_statuses) / 1e6)
         self.rss_free = int(data.rss_free / 1e6)
         self.free = data.free

--- a/scaler/ui/worker_processors.py
+++ b/scaler/ui/worker_processors.py
@@ -68,7 +68,7 @@ class WorkerProcessorTable:
 
     @staticmethod
     def draw_row(processor_status: ProcessorStatus, rss_free: int):
-        cpu = processor_status.resource.cpu / 10
+        cpu = min(processor_status.resource.cpu / 10, 100.0)
         rss = int(processor_status.resource.rss / 1e6)
         rss_free = int(rss_free / 1e6)
 


### PR DESCRIPTION
CPU usage reported by the scheduler sometimes exceeds 100 (eg. 100.4). This PR caps the displayed cpu value to 100 for better aesthetics.